### PR TITLE
Fix Windows permission error by using absolute path for log file

### DIFF
--- a/stockflow.py
+++ b/stockflow.py
@@ -1,5 +1,8 @@
 import logging
 import asyncio
+import os
+import sys
+from mcp import os
 import yfinance as yf
 from mcp.server import Server
 from mcp.types import Tool, TextContent
@@ -39,8 +42,8 @@ logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler("stockflow_v2.log"),
-        logging.StreamHandler()
+        logging.FileHandler(os.path.join(os.path.dirname(os.path.abspath(__file__)), "stockflow_v2.log")),
+        logging.StreamHandler(sys.stdout)
     ]
 )
 logger = logging.getLogger("stockflow-server-v2")


### PR DESCRIPTION
## PR Title:

Fix: Resolve PermissionError for log file on Windows Claude Desktop

## PR Description:

Describe the bug
Currently, Windows users running this MCP server via Claude Desktop encounter a PermissionError: [Errno 13] Permission denied: 'C:\\WINDOWS\\system32\\stockflow_v2.log'. This happens because there is a known bug in Claude Desktop on Windows where it ignores the "cwd" JSON parameter. As a result, Python defaults its working directory to System32, which blocks the creation of the log file and crashes the server.

## The Fix
This PR updates stockflow.py to use os.path.dirname(os.path.abspath(__file__)). This ensures stockflow_v2.log is always safely created in the exact same directory as the script itself, regardless of where Claude Desktop (or any other client) executes it from.

This change makes the server significantly more robust for Windows users without impacting Mac or Linux environments.